### PR TITLE
Retry button at cant´t umount and translations for german De_de

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cryptkeeper\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2010-06-03 17:56+0100\n"
 "Last-Translator: Josef Luštický <evramp@gmail.com>\n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,8 +24,10 @@ msgid "Cryptkeeper cannot access fuse and so cannot start"
 msgstr "Cryptkeeper nemá přístup k fuse a nemůže tak pokračovat"
 
 #: src/main.cpp:111
-msgid "Check that fuse is installed and that you are a member of the fuse group."
-msgstr "Zkontrolujte, zda je fuse nainstalováno a zda jeste členem skupiny fuse."
+msgid ""
+"Check that fuse is installed and that you are a member of the fuse group."
+msgstr ""
+"Zkontrolujte, zda je fuse nainstalováno a zda jeste členem skupiny fuse."
 
 #: src/main.cpp:127
 msgid "Cryptkeeper cannot find EncFS"
@@ -49,26 +52,34 @@ msgid "%s (%d instances)\n"
 msgstr "%s (%d instancí)\n"
 
 #: src/main.cpp:223
-msgid "The stash could not be unmounted because it is in use by the following applications:"
-msgstr "Tato úschovna nemohla být odpojena, protože je používáná následujícími aplikacemi:"
+msgid ""
+"The stash could not be unmounted because it is in use by the following "
+"applications:"
+msgstr ""
+"Tato úschovna nemohla být odpojena, protože je používáná následujícími "
+"aplikacemi:"
 
 #: src/main.cpp:227
 msgid "Kill them"
 msgstr "Zabít je"
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr "Úschovna nemohla být připojena. Chybné heslo?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr "Tato šifrovaná složka je dočasně nedostupná"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr "Může být na vyměnitelném disku nebo byla smazána."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -79,32 +90,31 @@ msgstr ""
 "Přípojný adresář: %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Jste si jisti, že chcete odstranit šifrovanou složku:"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Chcete trvale vymazat šifrovaná data:"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Informace"
 
-#: src/main.cpp:416
-#: src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Změnit heslo"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Smazat šifrovanou složku"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr "překladatelé-zásluhy"
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
@@ -114,20 +124,19 @@ msgstr ""
 "podle ustanovení Obecné veřejné licence GNU (GNU General Public Licence)\n"
 "3. verze, vydávané Free Software Foundation."
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Šifrované složky:</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Importovat složku EncFS"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Nová šifrovaná složka"
 
-#: src/ConfigDialog.cpp:56
-#: src/ConfigDialog.cpp:76
+#: src/ConfigDialog.cpp:56 src/ConfigDialog.cpp:76
 msgid "Cryptkeeper Preferences"
 msgstr "Cryptkeeper nastavení"
 
@@ -217,8 +226,12 @@ msgid "An error occurred while creating the encrypted folder"
 msgstr "Vyskytla se chyba při vytváření šifrované složky"
 
 #: src/CreateStashWizard.cpp:219
-msgid "Please check that the folder name you chose was not already used, and that encfs is installed correctly."
-msgstr "Prosím zkontrolujte, zda vybrané jméno složky už není používáno, a zda je encfs nainstalováno korektně."
+msgid ""
+"Please check that the folder name you chose was not already used, and that "
+"encfs is installed correctly."
+msgstr ""
+"Prosím zkontrolujte, zda vybrané jméno složky už není používáno, a zda je "
+"encfs nainstalováno korektně."
 
 #: src/ImportStashWizard.cpp:51
 msgid "Import an Encfs encrypted folder"
@@ -229,12 +242,15 @@ msgid "Select an existing EncFS encrypted folder (eg ~/.crypt)"
 msgstr "Vybrat existující složku šofrovanou EncFS (např. ~/.crypt)"
 
 #: src/ImportStashWizard.cpp:101
-msgid "Choose the name and location at which you want the EncFS folder to be mounted"
+msgid ""
+"Choose the name and location at which you want the EncFS folder to be mounted"
 msgstr "Vyberte jméno a umístění, do kterého chcete složku EncFS připojit"
 
 #: src/ImportStashWizard.cpp:116
-msgid "The EncFS encrypted folder has been successfully imported into Cryptkeeper"
-msgstr "Šifrovaná složka EncFS byla úspěšně importována do programu Cryptkeeper"
+msgid ""
+"The EncFS encrypted folder has been successfully imported into Cryptkeeper"
+msgstr ""
+"Šifrovaná složka EncFS byla úspěšně importována do programu Cryptkeeper"
 
 #: src/ImportStashWizard.cpp:164
 msgid "You must select a folder"
@@ -251,4 +267,3 @@ msgstr "Musíte vložit jméno"
 #: src/PasswordEntryDialog.cpp:40
 msgid "Enter your password:"
 msgstr "Vložte Vaše heslo"
-

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cryptkeeper 0.6.666\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2007-09-01 20:42+0100\n"
 "Last-Translator: Christoph Langner <mail@christoph-langner.de>\n"
 "Language-Team: English\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -33,7 +34,7 @@ msgstr "Cryptkeeper kann EncFS nicht finden"
 
 #: src/main.cpp:128
 msgid "Check that EncFS is installed and try again."
-msgstr ""
+msgstr "Bitte überprüfen sie ob fuse installiert ist und versuchen sie es erneut"
 
 #: src/main.cpp:170
 #, fuzzy
@@ -43,38 +44,42 @@ msgstr "Der neue verschlüsselte Ordner wurde erfolgreich angelegt"
 #: src/main.cpp:207
 #, c-format
 msgid "... %d others ..."
-msgstr ""
+msgstr "... %d weitere ..."
 
 #: src/main.cpp:212
 #, c-format
 msgid "%s (%d instances)\n"
-msgstr ""
+msgstr "%s (%d instanzen)\n"
 
 #: src/main.cpp:223
 msgid ""
 "The stash could not be unmounted because it is in use by the following "
 "applications:"
-msgstr ""
+msgstr "Mountpunkt konnte nicht gelöst werden, da dieser von folgenden Prozessen benutzt wird:"
 
 #: src/main.cpp:227
 msgid "Kill them"
-msgstr ""
+msgstr "Prozesse beeenden"
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr "Erneut versuchen"
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
-msgstr ""
+msgstr "Mountpunkt konnte nicht eingerichtet werden. Falsches Passwort?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
-msgstr ""
+msgstr "Der verschlüsselte Ordner ist nicht Verfügbar"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr ""
 "Das Verzeichnis wurde gelöscht oder lag eventuell auf einem "
 "Wechseldatenträger."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -85,31 +90,32 @@ msgstr ""
 "Mountpunkt: %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Sind sie sicher, dass sie den verschlüsselten Ordner löschen wollen:"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Möchten sie den verschlüsselten Daten permanent löschen:"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Informationen"
 
-#: src/main.cpp:416 src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Passwort ändern"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Verschlüsselten Ordner löschen"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr "Christoph Langner <mail@christoph-langner.de>"
+"Heinrich Schaefer <info@schaefer-heinrich.com>"
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
@@ -119,15 +125,15 @@ msgstr ""
 "Bedingungen der GNU General Public License Version 3, wie von der Free\n"
 "Software Foundation veröffentlicht, weiterverteilen und/oder modifizieren."
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Verschlüsselte Ordner:</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Importiere EncFS ordner"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Erstelle verschlüsselten Ordner "
 
@@ -149,11 +155,11 @@ msgstr "Ordner bei Nichgebrauch aushängen (Minuten):"
 
 #: src/ConfigDialog.cpp:112
 msgid "Do not delete mount point when unmounting"
-msgstr "Erhalte Mointpunkt nach dem Aushängen"
+msgstr "Erhalte Mountpunkt nach dem Aushängen"
 
 #: src/ConfigDialog.cpp:117
 msgid "Allow other users to access mounted folders"
-msgstr ""
+msgstr "Erlaube anderen Benutzern den Zugriff auf die entschlüsselten Ordner"
 
 #: src/PasswordChangeDialog.cpp:55
 msgid "The new passwords do not match"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cryptkeeper 0.6.666\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2007-07-12 19:26+0100\n"
 "Last-Translator: tom <tom@infoseed.co.uk>\n"
 "Language-Team: English\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ASCII\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -57,19 +58,23 @@ msgstr ""
 msgid "Kill them"
 msgstr ""
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr ""
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr ""
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr ""
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -77,46 +82,46 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr ""
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr ""
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr ""
 
-#: src/main.cpp:416 src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr ""
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr ""
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr ""
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
 "by the Free Software Foundation."
 msgstr ""
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr ""
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr ""
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr ""
 

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es_ES\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2009-09-29 12:48-0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -62,19 +63,23 @@ msgstr ""
 msgid "Kill them"
 msgstr "Mátalos"
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr "No ha sido posible montar el directorio. Contraseña errónea?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr "Esta carpeta cifrada no está disponible actualmente"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr "Podría encontrarse en un disco extraíble, o ha sido borrada."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -85,31 +90,31 @@ msgstr ""
 "Montar diretorio: %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Está seguro de querer eliminar la carpeta cifrada?"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Desea borrar de forma permanente los datos cifrados:"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Información"
 
-#: src/main.cpp:416 src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Cambiar contraseña:"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Eliminar carpeta cifrada"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr "pablito <pablitofuerte@gmail.com>"
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
@@ -119,15 +124,15 @@ msgstr ""
 "bajo los términos de la licencia GNU General Public License versión 3,\n"
 "según lo publicado por la Free Software Foundation."
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Carpetas cifradas:</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Importar carpeta cifrada"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Nueva carpeta cifrada"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cryptkeeper 0.6.666\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2007-07-16 22:32+0100\n"
 "Last-Translator: Jean-Sébastien Bour <sufflope@sufflope.net>\n"
 "Language-Team: French\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -63,19 +64,23 @@ msgstr ""
 msgid "Kill them"
 msgstr ""
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr "La cachette n'a pas pu être montée. Mot de passe incorrect ?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr "Ce dossier chiffré est actuellement indisponible"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr "Il est peut-être situé sur un disque amovible, ou a été effacé."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -86,32 +91,32 @@ msgstr ""
 "Dossier de montage : %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Êtes-vous sûr de vouloir effacer le dossier chiffré :"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 #, fuzzy
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Voulez-vous effacer définitivement les données chiffrées :"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Information"
 
-#: src/main.cpp:416 src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Modifier le mot de passe"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Effacer le dossier chiffré"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr "Jean-Sébastien Bour <sufflope@sufflope.net>"
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 #, fuzzy
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
@@ -123,15 +128,15 @@ msgstr ""
 "Licence GNU GPL (General Public License) version 3,\n"
 "comme publiée par la Free Software Fondation."
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Dossiers chiffrés :</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Importer un dossier EncFS"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Nouveau dossier chiffré"
 

--- a/po/hu_HU.po
+++ b/po/hu_HU.po
@@ -2,10 +2,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cryptkeeper\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Hrotkó Gábor <roti@al.pmmf.hu>\n"
 "Language-Team: Hrotkó Gábor <roti@al.pmmf.hu>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -17,7 +18,8 @@ msgid "Cryptkeeper cannot access fuse and so cannot start"
 msgstr "A Cryptkeeper nem fér hozzá a fuse-hez, így nem tud elindulni"
 
 #: src/main.cpp:111
-msgid "Check that fuse is installed and that you are a member of the fuse group."
+msgid ""
+"Check that fuse is installed and that you are a member of the fuse group."
 msgstr "Ellenőrizze hogy a fuse telepítve van, és ön a fuse csoport tagja."
 
 #: src/main.cpp:127
@@ -43,26 +45,34 @@ msgid "%s (%d instances)\n"
 msgstr "%s (%d példány(ok))\n"
 
 #: src/main.cpp:223
-msgid "The stash could not be unmounted because it is in use by the following applications:"
-msgstr "A rejtett adat nem csatlakoztatható le, mert a következő alkalmazás használja:"
+msgid ""
+"The stash could not be unmounted because it is in use by the following "
+"applications:"
+msgstr ""
+"A rejtett adat nem csatlakoztatható le, mert a következő alkalmazás "
+"használja:"
 
 #: src/main.cpp:227
 msgid "Kill them"
 msgstr "Elemek elpusztítása"
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr "A rejtett adat nem csatlakoztatható. Helytelen a jelszó?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr "Ez a titkosított könyvtár jelenleg nem elérhető"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr "Lehet hogy hordozható lemezen van, vagy törölt."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -73,52 +83,53 @@ msgstr ""
 "Csatolt mappa: %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Biztosan törölni szeretné ezt a titkosított mappát:"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Törölni szeretné a titkosítási adatokat véglegesen:"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Információ"
 
-#: src/main.cpp:416
-#: src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Jelszó megváltoztatása"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Titkosított mappa törlése"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr "fordítók"
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
 "by the Free Software Foundation."
-msgstr "Ez a program szabad szoftver, terjesztheti és/vagy módosíthatja a Free Software Foundation által kiadott GNU General Public License harmadik (vagy bármely későbbi) változatában foglaltak alapján."
+msgstr ""
+"Ez a program szabad szoftver, terjesztheti és/vagy módosíthatja a Free "
+"Software Foundation által kiadott GNU General Public License harmadik (vagy "
+"bármely későbbi) változatában foglaltak alapján."
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Titkosított könyvtárak:</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Titkosított mappa importálása"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Új titkosított mappa létrehozása"
 
-#: src/ConfigDialog.cpp:56
-#: src/ConfigDialog.cpp:76
+#: src/ConfigDialog.cpp:56 src/ConfigDialog.cpp:76
 msgid "Cryptkeeper Preferences"
 msgstr "Cryptkeeper beállítások"
 
@@ -208,8 +219,12 @@ msgid "An error occurred while creating the encrypted folder"
 msgstr "Hiba történt a titkosított mappa létrehozásakor"
 
 #: src/CreateStashWizard.cpp:219
-msgid "Please check that the folder name you chose was not already used, and that encfs is installed correctly."
-msgstr "Ellenőrizze hogy a választott könyvtárnév még nincs használatban, és az encfs megfelelően installálva van."
+msgid ""
+"Please check that the folder name you chose was not already used, and that "
+"encfs is installed correctly."
+msgstr ""
+"Ellenőrizze hogy a választott könyvtárnév még nincs használatban, és az "
+"encfs megfelelően installálva van."
 
 #: src/ImportStashWizard.cpp:51
 msgid "Import an Encfs encrypted folder"
@@ -220,11 +235,13 @@ msgid "Select an existing EncFS encrypted folder (eg ~/.crypt)"
 msgstr "Válasszon egy már meglévő EncFS titkosított könyvtárat (pl.: ~/.crypt)"
 
 #: src/ImportStashWizard.cpp:101
-msgid "Choose the name and location at which you want the EncFS folder to be mounted"
+msgid ""
+"Choose the name and location at which you want the EncFS folder to be mounted"
 msgstr "Válasszon nevet és helyet ahol a titkosított könyvtár csatolásra kerül"
 
 #: src/ImportStashWizard.cpp:116
-msgid "The EncFS encrypted folder has been successfully imported into Cryptkeeper"
+msgid ""
+"The EncFS encrypted folder has been successfully imported into Cryptkeeper"
 msgstr "Az EncFS titkosított könyvtárt sikeresen importáltuk a Cryptkeeperbe"
 
 #: src/ImportStashWizard.cpp:164
@@ -242,4 +259,3 @@ msgstr "Meg kell adnia egy nevet"
 #: src/PasswordEntryDialog.cpp:40
 msgid "Enter your password:"
 msgstr "Kérem, adja meg a jelszavát:"
-

--- a/po/it.po
+++ b/po/it.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cryptkeeper 0.6.666\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2007-07-16 22:32+0100\n"
 "Last-Translator: Martino Salvetti <the9ull@silix.org>\n"
 "Language-Team: Italian\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -60,19 +61,23 @@ msgstr ""
 msgid "Kill them"
 msgstr "Uccidili"
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr "La cartella non può essere montata. È corretta la password?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr "Questa cartella crittografata non è disponibile"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr "Potrebbe essere su un disco rimovibile, o essere stata rimossa."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -83,32 +88,32 @@ msgstr ""
 "Punto di mount : %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Sei sicuro di voler rimuovere la cartella crittografata:"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 #, fuzzy
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Vuoi eliminare in modo permanente i dati crittografati:"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Informationi"
 
-#: src/main.cpp:416 src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Cambia la password"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Elimina una cartella crittografata"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr "Martino Salvetti <the9ull@silix.org"
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
@@ -116,15 +121,15 @@ msgid ""
 msgstr ""
 
 # TODO
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Cartelle crittografate :</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Importa cartella EncFS"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Nuova cartella crittografata"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,16 +7,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cryptkeeper\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2009-01-02 20:43+0100\n"
 "Last-Translator: Franciszek Janowski <nobange@poczta.onet.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.11.4\n"
-"Plural-Forms:  nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%"
-"100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms:  nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n"
+"%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: src/main.cpp:110
 msgid "Cryptkeeper cannot access fuse and so cannot start"
@@ -62,20 +63,24 @@ msgstr ""
 msgid "Kill them"
 msgstr "Zabij je"
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr "Schowek nie mógł zostac zamontowany. Nieprawidłowe hasło?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr "Zaszyfrowany katalog jest obecnie niedostępny"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr ""
 "Być może jest on zlokalizowany na dysku przenośnym albo został usunięty."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -86,31 +91,31 @@ msgstr ""
 "Katalog montowania: %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Czy na pewno chcesz usunąć zaszyfrowany katalog:"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Czy chcesz ostatecznie skasować zaszyfrowane dane:"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Informacje"
 
-#: src/main.cpp:416 src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Zmień hasło"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Usuń zaszyfrowany katalog"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr "Franciszek Janowski (nobange@poczta.onet.pl)"
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
@@ -120,15 +125,15 @@ msgstr ""
 "under the terms of the GNU General Public License version 3, as published\n"
 "by the Free Software Foundation."
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Zaszyfrowane katalogi:</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Importuj katalog EncFS"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Nowy zaszyfrowany katalog"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,10 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pt_BR\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2008-05-02 15:46-0300\n"
 "Last-Translator: Phantom X <megaphantomx@bol.com.br>\n"
 "Language-Team: Português do Brasil <pt@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -61,19 +62,23 @@ msgstr ""
 msgid "Kill them"
 msgstr "Matá-los"
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr "Não é possível montar o estoque. Senha inválida?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr "A pasta criptografada não está disponível atualmente"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr "Ela pode se localizar num disco removível, ou foi apagado."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -84,31 +89,31 @@ msgstr ""
 "Montar diretório: %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Você tem certeza que deseja remover a pasta criptografada?"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Você deseja apagar permanentemente os dados criptografados?"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Informações"
 
-#: src/main.cpp:416 src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Alterar senha:"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Apagar pasta criptografada"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr "Phantom X <megaphantomx@bol.com.br>"
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
@@ -118,15 +123,15 @@ msgstr ""
 "sob os termos da GNU General Public License versão 3, como publicado\n"
 "pela Free Software Foundation."
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Pastas criptografadas:</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Importar pasta do EncFS"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Nova pasta criptografada"
 

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -2,10 +2,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2008-05-30 19:19+0300\n"
 "Last-Translator: Damir Sharipov <dammer@mail.ru>\n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -53,19 +54,23 @@ msgstr ""
 msgid "Kill them"
 msgstr "Убейте их"
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr "Хранилище не может быть смонтировано. Неправильный пароль?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr "Эта зашифрованная папка  в настоящее время недоступна"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr "Возможно расположена на сменном носителе или была удалена."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -76,46 +81,46 @@ msgstr ""
 "Точка монтирования: %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Вы уверенны в том, что хотите удалить зашифрованную папку:"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Вы точно хотите полностью стереть зашифрованные данные:"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Информация"
 
-#: src/main.cpp:416 src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Сменить пароль"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Удалить зашифрованную папку"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr ""
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
 "by the Free Software Foundation."
 msgstr ""
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Зашифрованные папки:</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Импорт папки EncFS"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Новая зашифрованная папка"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -2,10 +2,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cryptkeeper 0.9.1\n"
 "Report-Msgid-Bugs-To: t-morton@blueyonder.co.uk\n"
-"POT-Creation-Date: 2009-10-18 12:58+0100\n"
+"POT-Creation-Date: 2011-06-21 22:07+0200\n"
 "PO-Revision-Date: 2008-07-14 00:32+0200\n"
 "Last-Translator: Mert Dirik <mertdirik@gmail.com>\n"
 "Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -52,19 +53,23 @@ msgstr "Zula ayrılamadı; çünkü aşağıdaki uygulamalar hâlen zulayı kull
 msgid "Kill them"
 msgstr "Onları öldür"
 
-#: src/main.cpp:249
+#: src/main.cpp:228
+msgid "Retry"
+msgstr ""
+
+#: src/main.cpp:257
 msgid "The stash could not be mounted. Invalid password?"
 msgstr "Zula bağlanamadı. Yanlış parola girmediğinize emin misiniz?"
 
-#: src/main.cpp:263
+#: src/main.cpp:271
 msgid "This encrypted folder is currently not available"
 msgstr "Şifrelenmiş klasör şu anda mevcut değil"
 
-#: src/main.cpp:264
+#: src/main.cpp:272
 msgid "It may be located on a removable disk, or has been deleted."
 msgstr "Klasör çıkarılabilir bir sürücüde, ya da silinmiş olabilir."
 
-#: src/main.cpp:335
+#: src/main.cpp:343
 #, c-format
 msgid ""
 "Crypt directory: %s\n"
@@ -75,31 +80,31 @@ msgstr ""
 "Bağlama dizini: %s\n"
 "%s"
 
-#: src/main.cpp:369
+#: src/main.cpp:377
 msgid "Are you sure you want to remove the encrypted folder:"
 msgstr "Şifrelenmiş klasörü kaldırmak istediğinize emin misiniz?"
 
-#: src/main.cpp:384
+#: src/main.cpp:392
 msgid "Do you want to permanently erase the encrypted data:"
 msgstr "Şifrelenmiş veriyi kalıcı olarak silmek ister misiniz:"
 
-#: src/main.cpp:412
+#: src/main.cpp:420
 msgid "Information"
 msgstr "Bilgi"
 
-#: src/main.cpp:416 src/PasswordChangeDialog.cpp:95
+#: src/main.cpp:424 src/PasswordChangeDialog.cpp:95
 msgid "Change password"
 msgstr "Parolayı değiştir"
 
-#: src/main.cpp:420
+#: src/main.cpp:428
 msgid "Delete encrypted folder"
 msgstr "Şifrelenmiş klasörü sil"
 
-#: src/main.cpp:448
+#: src/main.cpp:456
 msgid "translator-credits"
 msgstr "Mert Dirik <mertdirik@gmail.com>"
 
-#: src/main.cpp:450
+#: src/main.cpp:458
 msgid ""
 "This program is free software; you can redistribute it and/or modify it\n"
 "under the terms of the GNU General Public License version 3, as published\n"
@@ -109,15 +114,15 @@ msgstr ""
 "Lisansı 3. versiyon şartları altında yeniden dağıtabilir ve / ya da "
 "değiştirebilirsiniz."
 
-#: src/main.cpp:486
+#: src/main.cpp:494
 msgid "<b>Encrypted folders:</b>"
 msgstr "<b>Şifrelenmiş Klasörler:</b>"
 
-#: src/main.cpp:534
+#: src/main.cpp:542
 msgid "Import EncFS folder"
 msgstr "Bir EncFS klasörünü içe aktar"
 
-#: src/main.cpp:538
+#: src/main.cpp:546
 msgid "New encrypted folder"
 msgstr "Yeni şifreli klasör"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,7 +225,24 @@ static void moan_cant_unmount (const char *mount_dir)
 			);
 	gtk_dialog_add_button (GTK_DIALOG (dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
 	gtk_dialog_add_button (GTK_DIALOG (dialog), _("Kill them"), GTK_RESPONSE_OK);
-	if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_OK) {
+	gtk_dialog_add_button (GTK_DIALOG (dialog), _("Retry"), GTK_RESPONSE_YES );
+	const gint response =  gtk_dialog_run (GTK_DIALOG (dialog)); 
+	if (response == GTK_RESPONSE_YES) {
+		gtk_widget_destroy (dialog);
+		
+		// renew list
+		get_fsusers(&ls, mount_dir);
+		if(ls.num.size() > 0){
+		// call moan_cant_unmount again
+		moan_cant_unmount(mount_dir);
+		}
+		else{
+		// unmount 
+		const char *mdir = strdup(mount_dir);
+		timeout_unmount((void*)mdir);
+		}
+	}
+	if (response == GTK_RESPONSE_OK) {
 		// renew list
 		get_fsusers(&ls, mount_dir);
 


### PR DESCRIPTION
Hi tomm,
i like cryptkeeper and use it every day. But i miss a retry button in the "cant´t umount" Dialog, so i code it :). My experience in gtk+ and C is not very good but i hope this code is ok anyway. I tested it on x86 Debian.

P.S. I updated the german translations also.

Bye
heinrich
